### PR TITLE
Change $unset prop values

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function set (query, field, val) {
 
 function unset (query, field) {
   query['$unset'] = query['$unset'] || {};
-  query['$unset'][field] = 1;
+  query['$unset'][field] = '';
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,162 @@
+{
+  "name": "mongo-update",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+      "integrity": "sha1-0bhvkB+LZL2UG96tr5JFMDk76Sg=",
+      "dev": true
+    },
+    "component-type": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.0.0.tgz",
+      "integrity": "sha1-HtiBLjLdZQmdQzVwdX8RHqPT2HE="
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "diff": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
+      "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+      "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "2.0.3",
+        "inherits": "2.0.3",
+        "minimatch": "0.2.14"
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+      "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz",
+      "integrity": "sha1-3i1mE20ALhErpw8/EMMc98NQsto=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.7.3",
+        "sigmund": "1.0.1"
+      }
+    },
+    "mkdirp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+      "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
+      "dev": true
+    },
+    "mocha": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.17.1.tgz",
+      "integrity": "sha1-f3Zx1oUm0HS3uuZgyQmfh+DqHMs=",
+      "dev": true,
+      "requires": {
+        "commander": "2.0.0",
+        "debug": "3.1.0",
+        "diff": "1.0.7",
+        "glob": "3.2.3",
+        "growl": "1.7.0",
+        "jade": "0.26.3",
+        "mkdirp": "0.3.5"
+      }
+    },
+    "mongo-eql": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mongo-eql/-/mongo-eql-0.1.1.tgz",
+      "integrity": "sha1-5Y43GWtG/qqZtE3vvtN5r+j8qf0=",
+      "requires": {
+        "debug": "3.1.0",
+        "type-component": "0.0.1"
+      }
+    },
+    "mongo-minify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mongo-minify/-/mongo-minify-0.1.1.tgz",
+      "integrity": "sha1-gZbGU2SkjxRxeeEwzp/aSwGEpSs=",
+      "requires": {
+        "object-component": "0.0.3",
+        "type-component": "0.0.1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "type-component": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/type-component/-/type-component-0.0.1.tgz",
+      "integrity": "sha1-lSpsgcIe/STRPYEdDISYy4YOGVY="
+    }
+  }
+}

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ describe('query()', function () {
   
   it('should $unset null-ish keys', function () {
     var query = diff({ a: 1 }, { a: null });
-    assert(query.$unset.a == 1);
+    assert(query.$unset.a == '');
     assert(!('$set' in query));
   });
   
@@ -23,7 +23,7 @@ describe('query()', function () {
   it('should work with nested keys', function () {
     var query = diff({ a: { b: 1, c: 2 }}, { a: { b: 2, c: null }});
     assert(query.$set['a.b'] == 2);
-    assert(query.$unset['a.c'] == 1);
+    assert(query.$unset['a.c'] == '');
   });
   
   describe('when given a filter', function () {


### PR DESCRIPTION
The property value of the keys that are specified in Mongo's [$unset operator](https://docs.mongodb.com/manual/reference/operator/update/unset/) don't matter:
> The specified value in the $unset expression (i.e. "") does not impact the operation.

Therefore I think that it's an improvement in clarity to change this library to set the `$unset` property values to an empty string `''` instead of `1` for two reasons:

1. I want to store the changes of the update in my database.  Currently, the fact that `$unset` properties have a value of `1` makes this confusing, for example: 
`{ 'name': 1 }` vs `{ 'name': '' }`

The latter is simply more intuitive for unsetting.  It allows one to store the value of `$unset` as the change without an extraneous formatting step.

2. The [official Mongo docs for $unset](https://docs.mongodb.com/manual/reference/operator/update/unset/) use an empty string.  Changing this library to use `''` instead of `1` maintains a more obvious parity w/ the Mongo docs, and is therefore easier to understand.